### PR TITLE
Move workflow request models to schemas

### DIFF
--- a/backend/app/api/v1/endpoints/workflows.py
+++ b/backend/app/api/v1/endpoints/workflows.py
@@ -1,23 +1,13 @@
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel, Field
 
 from app.services.workflow_service import WorkflowService
+from app.schemas.workflow import StartWorkflowRequest, CompleteTaskRequest
 
 
 router = APIRouter()
 
 
-class StartWorkflowRequest(BaseModel):
-    name: str = Field(default="Simple Approval")
-    bpmn_filename: str = Field(default="simple_approval.bpmn")
-    process_id: str = Field(default="SimpleApproval")
-
-
-class CompleteTaskRequest(BaseModel):
-    class ApprovalData(BaseModel):
-        approved: bool
-
-    data: ApprovalData
+ 
 
 
 @router.post("/start", summary="Start a new workflow instance")

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,1 +1,1 @@
-# Schemas Package
+from .workflow import StartWorkflowRequest, CompleteTaskRequest

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,1 +1,1 @@
-from .workflow import StartWorkflowRequest, CompleteTaskRequest
+ 

--- a/backend/app/schemas/workflow.py
+++ b/backend/app/schemas/workflow.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel, Field
+
+
+class StartWorkflowRequest(BaseModel):
+    name: str = Field(default="Simple Approval")
+    bpmn_filename: str = Field(default="simple_approval.bpmn")
+    process_id: str = Field(default="SimpleApproval")
+
+
+class CompleteTaskRequest(BaseModel):
+    class ApprovalData(BaseModel):
+        approved: bool
+
+    data: ApprovalData
+


### PR DESCRIPTION
Move `StartWorkflowRequest` and `CompleteTaskRequest` Pydantic models to `app/schemas/workflow.py` for better code organization.

---
<a href="https://cursor.com/background-agent?bcId=bc-29a6be41-702f-4b88-9aca-82122d2d9233">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-29a6be41-702f-4b88-9aca-82122d2d9233">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

